### PR TITLE
Chrissy's contribution of the word "cycle"

### DIFF
--- a/_data/dictionary/cycle.yaml
+++ b/_data/dictionary/cycle.yaml
@@ -6,6 +6,6 @@ definition_list:
       - text: The defense sector steered $18.9 million in campaign contributions to members of the 118th Congress during the 2022 election cycle.
         source: Open Secrets
         url: https://www.opensecrets.org/news/2023/03/armed-services-committee-members-received-5-8-million-from-defense-sector-during-2022-election-cycle/
-      - text: "The cycle of supercharged borrowing began with the 2008 financial crisis and recession, when governments rushed to provide assistance to struggling households and tax revenues fell."
-        source: New York Times
-        url: https://www.nytimes.com/2026/01/27/business/economy/government-debt-bonds.html?searchResultPosition=1
+      - text: Presidential candidates raised $2 billion and spent approximately $1.8 billion in the 24 months of the 2023-2024 election cycle.
+        source: FEC.gov
+        url: https://www.fec.gov/updates/statistical-summary-of-24-month-campaign-activity-of-the-2023-2024-election-cycle/

--- a/_data/dictionary/cycle.yaml
+++ b/_data/dictionary/cycle.yaml
@@ -6,3 +6,6 @@ definition_list:
       - text: The defense sector steered $18.9 million in campaign contributions to members of the 118th Congress during the 2022 election cycle.
         source: Open Secrets
         url: https://www.opensecrets.org/news/2023/03/armed-services-committee-members-received-5-8-million-from-defense-sector-during-2022-election-cycle/
+      - text: "The cycle of supercharged borrowing began with the 2008 financial crisis and recession, when governments rushed to provide assistance to struggling households and tax revenues fell."
+        source: New York Times
+        url: https://www.nytimes.com/2026/01/27/business/economy/government-debt-bonds.html?searchResultPosition=1


### PR DESCRIPTION
I add a quote for the word "cycle".
The quote is "The cycle of supercharged borrowing began with the 2008 financial crisis and recession, when governments rushed to provide assistance to struggling households and tax revenues fell."
https://www.nytimes.com/2026/01/27/business/economy/government-debt-bonds.html?searchResultPosition=1 
